### PR TITLE
Add variables for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PLUGIN_NAME=valuya/curlftpfs
+PLUGIN_TAG=next
 
 all: clean docker rootfs create
 


### PR DESCRIPTION
Plugin cannot be created without `PLUGIN_NAME` and `PLUGIN_TAG` variables set